### PR TITLE
switch from expiring token in kubeconfig to auth: gcp

### DIFF
--- a/terraform/modules/gcloud-k8s/main.tf
+++ b/terraform/modules/gcloud-k8s/main.tf
@@ -40,7 +40,6 @@ data "template_file" "kubeconfig" {
     cluster_name  = google_container_cluster.default.name
     endpoint      = google_container_cluster.default.endpoint
     cluster_ca    = google_container_cluster.default.master_auth[0].cluster_ca_certificate
-    cluster_token = data.google_client_config.default.access_token
   }
 }
 

--- a/terraform/modules/gcloud-k8s/templates/kubeconfig-template.yaml
+++ b/terraform/modules/gcloud-k8s/templates/kubeconfig-template.yaml
@@ -12,7 +12,8 @@ contexts:
 users:
 - name: ${cluster_name}
   user:
-    token: ${cluster_token}
+    auth-provider: 
+      name: gcp
 current-context: ${cluster_name}
 kind: Config
 preferences: {}


### PR DESCRIPTION
Suggest a small tweak to the bundle to generate a kubeconfig referencing GCP auth as opposed to the token (since that expires a short time later and currently requires pulling gcloud in to any bundle that wants to build off the cluster to re-auth). This blog post describes the process: 

https://ahmet.im/blog/authenticating-to-gke-without-gcloud/

On a 'dependent' bundle, all you then need is somthing like this as opposed to re-issuing the gcloud auth / cluster config get stuff. 

credentials:
  - name: kubeconfig
    path: /root/.kube/config
  - name: gcloud-key-file
    path: /cnab/app/gcloud.json

parameters:
  - name: google-application-credentials
    type: string
    env: GOOGLE_APPLICATION_CREDENTIALS
    default: /cnab/app/gcloud.json

If there are better ways to make downstream bundles more provider agnostic we should look at that lest we end up with GCP / AWS / AZure flavored varients of everything we want to package.